### PR TITLE
On negotiate PoC

### DIFF
--- a/examples/reflect/data_channel.rs
+++ b/examples/reflect/data_channel.rs
@@ -10,13 +10,13 @@ pub enum Message {
     Message(DataChannelMessage),
 }
 
+#[derive(Clone)]
 pub struct DataChannel {
     inner: Arc<RTCDataChannel>,
-    incoming_rx: Receiver<Message>,
 }
 
 impl DataChannel {
-    pub async fn new(inner: Arc<RTCDataChannel>) -> Self {
+    pub async fn new(inner: Arc<RTCDataChannel>) -> (Self, Receiver<Message>) {
         let (incoming_tx, incoming_rx) = mpsc::channel(1000);
 
         {
@@ -58,14 +58,7 @@ impl DataChannel {
                 .await;
         }
 
-        Self { inner, incoming_rx }
-    }
-
-    pub async fn next_message(&mut self) -> Message {
-        self.incoming_rx
-            .recv()
-            .await
-            .expect("Failed to receive incoming data channel message")
+        (Self { inner }, incoming_rx)
     }
 
     pub async fn send_text(&self, v: String) {

--- a/examples/reflect/data_channel.rs
+++ b/examples/reflect/data_channel.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use tokio::sync::mpsc::{self, Receiver};
+use webrtc::data_channel::{data_channel_message::DataChannelMessage, RTCDataChannel};
+
+#[derive(Debug)]
+pub enum Message {
+    Closed,
+    Opened,
+    Message(DataChannelMessage),
+}
+
+pub struct DataChannel {
+    inner: Arc<RTCDataChannel>,
+    incoming_rx: Receiver<Message>,
+}
+
+impl DataChannel {
+    pub async fn new(inner: Arc<RTCDataChannel>) -> Self {
+        let (incoming_tx, incoming_rx) = mpsc::channel(1000);
+
+        {
+            let incoming_tx = incoming_tx.clone();
+            inner
+                .on_open(Box::new(move || {
+                    let incoming_tx = incoming_tx.clone();
+
+                    Box::pin(async move {
+                        let _ = incoming_tx.send(Message::Opened).await;
+                    })
+                }))
+                .await;
+        }
+
+        {
+            let incoming_tx = incoming_tx.clone();
+            inner
+                .on_close(Box::new(move || {
+                    let incoming_tx = incoming_tx.clone();
+
+                    Box::pin(async move {
+                        let _ = incoming_tx.send(Message::Closed).await;
+                    })
+                }))
+                .await;
+        }
+
+        {
+            let incoming_tx = incoming_tx.clone();
+            inner
+                .on_message(Box::new(move |message| {
+                    let incoming_tx = incoming_tx.clone();
+
+                    Box::pin(async move {
+                        let _ = incoming_tx.send(Message::Message(message)).await;
+                    })
+                }))
+                .await;
+        }
+
+        Self { inner, incoming_rx }
+    }
+
+    pub async fn next_message(&mut self) -> Message {
+        self.incoming_rx
+            .recv()
+            .await
+            .expect("Failed to receive incoming data channel message")
+    }
+
+    pub async fn send_text(&self, v: String) {
+        self.inner
+            .send_text(v)
+            .await
+            .expect("failed to send message");
+    }
+}


### PR DESCRIPTION
This is a modified version of the reflect example. Instead of adding the reflected output tracks immediately it waits until the remote track is added and adds the corresponding output track at this point instead. 

**NOTE:** Even if the negotiate callback fired correctly it wouldn't work because the negotiation over the data channel is not implemented.

Lowering the debug log verbosity from `Trace` to `Debug` is advisable


## Steps

1. Use the following [JSFiddle](https://jsfiddle.net/82cbh3oL/1/)
2. Build the example
3. Run it with the SDP from the fiddle(make sure to turn on debug mode)

## Expected behaviour

Adding a new output track in response to an incoming track in `on_track` should cause the `on_negotiation_needed` callback to fire. If the data channel was wired up to do the negotiation in response to this it would have have the effect of the code working as intended.

## Actual behaviour

The `on_negotiation_needed` callback never fires, "Negotiation needed fired" never appears in the log.

## Environment

M1 Macbook Pro running macOS 12.0.1, Google chrome