### PR TITLE
Create offer issue

### DIFF
--- a/examples/reflect/reflect.rs
+++ b/examples/reflect/reflect.rs
@@ -315,6 +315,11 @@ async fn main() -> Result<()> {
     println!("Press ctrl-c to stop");
     //let timeout = tokio::time::sleep(Duration::from_secs(20));
     //tokio::pin!(timeout);
+    //
+    peer_connection
+        .create_offer(None)
+        .await
+        .expect("Failed to create offer");
 
     tokio::select! {
         //_ = timeout.as_mut() => {


### PR DESCRIPTION
I noticed this issue when debugging something else.

## To reproduce

Run the reflect demo according to the usual instructions. Pass `--video` to use video mode.

## Expected behaviour

Running `create_offer` after the signalling state has become stable should be okay.

## Actual behaviour

`create_offer` returns `ErrExcessiveRetries`.


## Details


Here, when we call `create_offer` on line 318 the signalling state is stable. However, `create_offer` fails. It does so because there is a transceiver for the audio track that was initially offered, but then rejected in the response. 

Specfically, `has_local_description_changed` returns true on this line:

https://github.com/webrtc-rs/webrtc/blob/f0a3362b6f18494077b3551f12f154ee79e717db/src/peer_connection/peer_connection_internal.rs#L1314

Because there will exist a transceiver with some `mid`(typically "0" in my tests) , but that `mid` will not be present in the proposed SDP for the new offer.

