### PR TITLE
Add main parts of SFU example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ serde_json = "1.0.75"
 bytes = "1.1.0"
 lazy_static = "1.4.0"
 rand = "0.8.4"
+flume = "0.10.12"
+hyper-tungstenite = "0.6.0"
+futures = "0.3"
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [profile.dev]
 opt-level = 0
@@ -147,4 +151,9 @@ bench = false
 [[example]]
 name = "ice-restart"
 path = "examples/ice-restart/ice-restart.rs"
+bench = false
+
+[[example]]
+name = "sfu"
+path = "examples/sfu/main.rs"
 bench = false

--- a/examples/sfu/README.md
+++ b/examples/sfu/README.md
@@ -1,0 +1,17 @@
+# SFU
+
+This is a simplified example of how you may build an SFU (Selective Forwarding Unit) with `webrtc-rs`. It demonstrates the following:
+
+- Other peers joining the call
+- Trickle ICE
+- Re-negotiation
+- Audio with Opus and video with VP8
+
+## Building
+
+Run the build:
+```
+cargo build --example sfu
+```
+
+Navigate to `http://localhost:8081` in one browser/tab, and then open it again in another browser/tab.

--- a/examples/sfu/index.html
+++ b/examples/sfu/index.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>SFU Example</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+
+  <main>
+    <h1>Peer ID: <span id="uuid"></span></h1>
+    <div id="signalingContainer" style="display: none">
+      <h2>Browser base64 Session Description</h2>
+      <textarea id="localSessionDescription" readonly></textarea>
+
+      <h2>Golang base64 Session Description</h2>
+      <textarea id="remoteSessionDescription"></textarea>
+    </div>
+
+    <h2>Local Video</h2>
+    <video id="local" width="160" height="120" autoplay muted></video>
+    <h2>Remote Videos</h2>
+    <div id="remoteVideos"></div> <br />
+
+    <div class="grid">
+      <div>
+        <h4>Local SDP</h4>
+        <pre>{pc?.localDescription?.sdp}</pre>
+      </div>
+      <div>
+        <h4>Remote SDP</h4>
+        <pre>{pc?.remoteDescription?.sdp}</pre>
+      </div>
+    </div>
+
+    <h2>Logs</h2>
+    <div id="logs"></div>
+  </main>
+
+  <script>
+    let pc
+    let uuidEl = document.querySelector('#uuid')
+
+    function randomId() {
+      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        let r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8)
+        return v.toString(16)
+      })
+    }
+
+    let uuid = randomId()
+    uuidEl.innerHTML = uuid
+
+    let ws = new WebSocket("ws://localhost:8081")
+
+    ws.onopen = async _e => {
+      console.log("Connection established. Creating peer.")
+      pc = await createPeerConnection()
+      connect()
+    }
+
+    ws.onmessage = async (event) => {
+      let msg = JSON.parse(event.data)
+
+      switch (msg.event) {
+        case 'answer': {
+          let answer = JSON.parse(msg.data)
+          console.warn("Got this answer:", answer)
+          if (!answer) { return console.log('failed to parse offer') }
+
+          await pc.setRemoteDescription(answer)
+
+          return
+        }
+        case 'offer': {
+          let offer = JSON.parse(msg.data)
+          if (!offer) { return console.log('failed to parse offer') }
+
+          console.warn("Got this offer:", offer)
+
+          console.log(pc.getSenders())
+          await pc.setRemoteDescription(offer)
+
+          const answer = await pc.createAnswer()
+          console.warn('Sending answer.', answer)
+          await pc.setLocalDescription(answer)
+
+          ws.send(JSON.stringify({
+            event: "answer",
+            data: answer.sdp,
+            uuid: msg.uuid
+          }))
+
+          return
+        }
+        case 'candidate': {
+          let candidate = JSON.parse(msg.data)
+          if (!candidate) {
+            return console.log('failed to parse candidate')
+          }
+
+          pc.addIceCandidate(candidate)
+        }
+      }
+    }
+
+    const connect = async () => {
+      const offer = await pc.createOffer()
+      await pc.setLocalDescription(offer)
+
+      console.warn('Sending offer.', offer)
+      ws.send(JSON.stringify({
+        event: "offer",
+        data: offer.sdp,
+        uuid: uuid
+      }))
+    }
+
+    const createPeerConnection = async () => {
+      let stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true })
+
+      let pc = new RTCPeerConnection({
+        iceServers: [
+          {
+            urls: 'stun:stun.l.google.com:19302'
+          }
+        ]
+      })
+
+      pc.ontrack = function (event) {
+        console.log("Got a new track!", event)
+
+        if (event.track.kind === 'audio') {
+          return
+        }
+
+        let el = document.createElement(event.track.kind)
+        el.srcObject = event.streams[0]
+        el.autoplay = true
+        el.controls = true
+        document.getElementById('remoteVideos').appendChild(el)
+
+        event.track.onmute = function(event) {
+          el.play()
+        }
+
+        event.streams[0].onremovetrack = ({track}) => {
+          if (el.parentNode) {
+            el.parentNode.removeChild(el)
+          }
+        }
+      }
+
+      pc.oniceconnectionstatechange = e => console.warn(pc.iceConnectionState)
+
+      pc.onicecandidate = e => {
+        if (!e.candidate) {
+          return
+        }
+
+        ws.send(JSON.stringify({event: 'candidate', uuid, data: JSON.stringify(e.candidate)}))
+      }
+
+      stream.getTracks().forEach(track => pc.addTrack(track, stream));
+      let el = document.getElementById('local')
+      el.srcObject = stream
+
+      return pc
+    }
+  </script>
+</body>
+</html>

--- a/examples/sfu/main.rs
+++ b/examples/sfu/main.rs
@@ -1,0 +1,96 @@
+use anyhow::Result;
+use sfu::signal::SocketMessage;
+use std::sync::Arc;
+use webrtc::{track::track_remote::TrackRemote, rtp::packet::Packet, rtp_transceiver::rtp_codec::RTPCodecType};
+use flume::{Sender, Receiver};
+
+mod sfu;
+
+#[derive(Debug, Clone)]
+pub enum PeerChanCommand {
+    SendIceCandidate {
+        uuid: String,
+        candidate: String,
+    },
+    ReceiveIceCandidate {
+        uuid: String,
+        candidate: String,
+    },
+    SendOffer {
+        uuid: String
+    },
+    ReceiveOffer {
+        uuid: String,
+        sdp: String,
+        tx: Sender<SocketMessage>
+    },
+    ReceiveAnswer {
+        uuid: String,
+        sdp: String,
+    },
+    OnTrack {
+        uuid: String,
+        track: Arc<TrackRemote>
+    },
+    DistributePacket {
+        uuid: String,
+        packet: Packet,
+        kind: RTPCodecType
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let new_conn_rx = sfu::signal::ws_sdp_signaler(8081).await;
+
+    let (peer_chan_tx, peer_chan_rx) = flume::unbounded::<PeerChanCommand>();
+
+    let tx_clone_1 = peer_chan_tx.clone();
+    let tx_clone_2 = peer_chan_tx.clone();
+
+    tokio::spawn(async move {
+        sfu::media::handle_peer_connection_commands(peer_chan_rx, tx_clone_1.clone()).await.unwrap();
+    });
+
+    while let Ok((uuid, socket_tx, socket_rx)) = new_conn_rx.recv_async().await {
+        handle_new_connection(&uuid, tx_clone_2.clone(), socket_tx, socket_rx).await.unwrap();
+    };
+
+    Ok(())
+}
+
+// Handler to spin off for every new connection.
+async fn handle_new_connection(_uuid: &String, peer_chan_tx: Sender<PeerChanCommand>, socket_tx: Sender<SocketMessage>, socket_rx: Receiver<SocketMessage>) -> Result<()> {
+    tokio::spawn(async move {
+        println!("Handling a new connection.");
+        while let Ok(signal) = socket_rx.recv_async().await {
+            match signal {
+                SocketMessage { event, uuid: id, data: sdp } if event == "offer" => {
+                    println!("\nReceiving offer: {:?}, for uuid: {:?}\n", sdp, id);
+                    peer_chan_tx.send(PeerChanCommand::ReceiveOffer {
+                        uuid: id.to_owned(),
+                        tx: socket_tx.clone(),
+                        sdp
+                    }).unwrap();
+                },
+                SocketMessage { event, uuid: id, data: sdp } if event == "answer" => {
+                    println!("\nReceiving answer: {:?}, for uuid: {:?}\n", sdp, id);
+                    peer_chan_tx.send(PeerChanCommand::ReceiveAnswer {
+                        uuid: id.to_owned(),
+                        sdp
+                    }).unwrap();
+                },
+                SocketMessage { event, uuid: id, data: candidate } if event == "candidate" => {
+                    println!("\nReceiving ice candidate, for uuid: {:?}\n", id);
+                    peer_chan_tx.send(PeerChanCommand::ReceiveIceCandidate {
+                        uuid: id.to_owned(),
+                        candidate
+                    }).unwrap();
+                },
+                _ => ()
+            }
+        };
+    });
+
+    Ok(())
+}

--- a/examples/sfu/sfu.rs
+++ b/examples/sfu/sfu.rs
@@ -1,0 +1,3 @@
+pub mod signal; 
+pub mod api; 
+pub mod media; 

--- a/examples/sfu/sfu/api.rs
+++ b/examples/sfu/sfu/api.rs
@@ -1,0 +1,81 @@
+use anyhow::Result;
+use webrtc::api::API;
+use webrtc::api::interceptor_registry::register_default_interceptors;
+use webrtc::api::media_engine::{MediaEngine, MIME_TYPE_VP8, MIME_TYPE_OPUS};
+use webrtc::api::APIBuilder;
+use webrtc::ice_transport::ice_server::RTCIceServer;
+use webrtc::interceptor::registry::Registry;
+use webrtc::peer_connection::configuration::RTCConfiguration;
+use webrtc::rtp_transceiver::rtp_codec::{RTPCodecType, RTCRtpCodecCapability, RTCRtpCodecParameters};
+
+
+pub fn prepare_api() -> Result<API, anyhow::Error> {
+    let audio = true;
+    let video = true;
+
+    // Create a MediaEngine object to configure the supported codec
+    let mut m = MediaEngine::default();
+
+    // Setup the codecs you want to use.
+    if audio {
+        m.register_codec(
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: MIME_TYPE_OPUS.to_owned(),
+                    ..Default::default()
+                },
+                payload_type: 120,
+                ..Default::default()
+            },
+            RTPCodecType::Audio,
+        )?;
+    }
+
+    // We'll use a VP8 and Opus but you can also define your own
+    if video {
+        m.register_codec(
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: MIME_TYPE_VP8.to_owned(),
+                    clock_rate: 90000,
+                    channels: 0,
+                    sdp_fmtp_line: "".to_owned(),
+                    rtcp_feedback: vec![],
+                },
+                payload_type: 96,
+                ..Default::default()
+            },
+            RTPCodecType::Video,
+        )?;
+    }
+
+    // Create a InterceptorRegistry. This is the user configurable RTP/RTCP Pipeline.
+    // This provides NACKs, RTCP Reports and other features. If you use `webrtc.NewPeerConnection`
+    // this is enabled by default. If you are manually managing You MUST create a InterceptorRegistry
+    // for each PeerConnection.
+    let mut registry = Registry::new();
+
+    // Use the default set of Interceptors
+    registry = register_default_interceptors(registry, &mut m)?;
+
+    // Create the API object with the MediaEngine
+    let api = APIBuilder::new()
+        .with_media_engine(m)
+        .with_interceptor_registry(registry)
+        .build();
+
+    Ok(api)
+}
+
+pub fn prepare_configuration() -> Result<RTCConfiguration, anyhow::Error> {
+    // Prepare the configuration
+    let config = RTCConfiguration {
+        ice_servers: vec![RTCIceServer {
+            urls: vec!["stun:stun.l.google.com:19302".to_owned()],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    Ok(config)
+}

--- a/examples/sfu/sfu/media.rs
+++ b/examples/sfu/sfu/media.rs
@@ -1,0 +1,364 @@
+use anyhow::Result;
+use webrtc::api::media_engine::{MIME_TYPE_VP8, MIME_TYPE_OPUS};
+use webrtc::ice_transport::ice_connection_state::RTCIceConnectionState;
+use webrtc::ice_transport::ice_gatherer_state::RTCIceGathererState;
+use webrtc::rtp_transceiver::rtp_codec::{RTCRtpCodecCapability, RTPCodecType};
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+use webrtc::ice_transport::ice_candidate::{RTCIceCandidate, RTCIceCandidateInit};
+use webrtc::peer_connection::RTCPeerConnection;
+use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
+use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
+use webrtc::rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndication;
+use webrtc::rtp_transceiver::rtp_receiver::RTCRtpReceiver;
+use webrtc::track::track_local::track_local_static_rtp::TrackLocalStaticRTP;
+use webrtc::track::track_local::{TrackLocal, TrackLocalWriter};
+use webrtc::track::track_remote::TrackRemote;
+use flume::Sender;
+use flume::Receiver;
+use std::collections::HashMap;
+use crate::sfu::signal::SocketMessage;
+use crate::PeerChanCommand;
+
+#[derive(Clone)]
+pub struct Peer {
+    // The peer connection itself
+    pub pc: Arc<RTCPeerConnection>,
+    // Copy of the socket to transmit back on
+    pub tx: Sender<SocketMessage>,
+    pub local_video_tracks: HashMap<String, Arc<TrackLocalStaticRTP>>,
+    pub local_audio_tracks: HashMap<String, Arc<TrackLocalStaticRTP>>,
+    // The remote tracks on which rtp packets are read in from
+    pub remote_video_track: Option<Arc<TrackRemote>>,
+    pub remote_audio_track: Option<Arc<TrackRemote>>,
+    // The id for this peer in the call
+    pub uuid: String,
+}
+
+impl fmt::Debug for Peer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Peer")
+            .field("uuid", &self.uuid)
+            .finish()
+    }
+}
+
+impl Peer {
+    async fn add_local_tracks(&mut self, uuid: String) -> anyhow::Result<()> {
+        println!("Adding track to {}", uuid);
+        for s in MEDIA.clone() {
+            let local_track = Arc::new(TrackLocalStaticRTP::new(
+                    RTCRtpCodecCapability {
+                        mime_type: if s == "video" {
+                            MIME_TYPE_VP8.to_owned()
+                        } else {
+                            MIME_TYPE_OPUS.to_owned()
+                        },
+                        ..Default::default()
+                    },
+                    format!("track-{}", s),
+                    format!("webrtc-rs-{}", uuid)
+            ));
+
+            // Add this newly created local track to the PeerConnection
+            let rtp_sender = self.pc
+                .add_track(Arc::clone(&local_track) as Arc<dyn TrackLocal + Send + Sync>)
+                .await?;
+
+            // Read incoming RTCP packets forever.
+            // Before these packets are returned they are processed by interceptors. For things
+            // like NACK this needs to be called.
+            let m = s.to_owned();
+            tokio::spawn(async move {
+                let mut rtcp_buf = vec![0u8; 1500];
+                while let Ok((_, _)) = rtp_sender.read(&mut rtcp_buf).await {}
+                println!("{} rtp_sender.read loop exit", m);
+                Result::<()>::Ok(())
+            });
+
+            if s == "video" {
+                self.local_video_tracks.insert(uuid.to_owned(), local_track);
+            } else if s == "audio" {
+                self.local_audio_tracks.insert(uuid.to_owned(), local_track);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn set_pc_callbacks(&mut self, peer_chan_tx: Sender<PeerChanCommand>) -> anyhow::Result<()> {
+        // Set the handler for when renegotiation needs to happen
+        let tx_clone = peer_chan_tx.clone();
+        let uuid = self.uuid.clone();
+        self.pc
+            .on_negotiation_needed(Box::new(move || {
+                println!("{} Peer Connection needs negotiation.", uuid);
+                let cloned_tx = tx_clone.clone();
+                let cloned_id = uuid.clone();
+
+                Box::pin(async move {
+                    cloned_tx.send(PeerChanCommand::SendOffer {
+                        uuid: cloned_id.to_owned(),
+                    }).unwrap();
+                })
+            }))
+        .await;
+
+        // Set the handler for receiving a new trickle ice candidate.
+        let tx_clone = peer_chan_tx.clone();
+        let mut uuid = self.uuid.clone();
+        self.pc
+            .on_ice_candidate(Box::new(move |candidate: Option<RTCIceCandidate>| {
+                let cloned_tx = tx_clone.clone();
+                let cloned_id = uuid.clone();
+
+                Box::pin(async move {
+                    if !candidate.is_none() {
+                        cloned_tx.send(PeerChanCommand::SendIceCandidate {
+                            uuid: cloned_id.to_owned(),
+                            candidate: serde_json::to_string(&candidate.unwrap()).unwrap(),
+                        }).unwrap();
+                    }
+                })
+            })).await;
+
+        self.pc
+            .on_ice_gathering_state_change(Box::new(move |s: RTCIceGathererState| {
+                println!("On ice gathering state change, {}", s);
+                Box::pin(async {})
+            })).await;
+
+        self.pc
+            .on_ice_connection_state_change(Box::new(move |s: RTCIceConnectionState| {
+                println!("On ice connection state change, {}", s);
+                Box::pin(async {})
+            })).await;
+
+
+        self.pc
+            .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+                println!("Peer Connection State has changed: {}", s);
+                Box::pin(async {})
+            })).await;
+
+        // Set a handler for when a new remote track starts, this handler copies inbound RTP packets,
+        // replaces the SSRC and sends them back
+        let tx_clone = peer_chan_tx.clone();
+        uuid = self.uuid.clone();
+        self.pc
+            .on_track(Box::new(
+                    move |track: Option<Arc<TrackRemote>>, _receiver: Option<Arc<RTCRtpReceiver>>| {
+                        if let Some(track) = track {
+                            tx_clone.send(PeerChanCommand::OnTrack {
+                                uuid: uuid.to_owned(),
+                                track
+                            }).unwrap();
+                        }
+                        Box::pin(async {})
+                    },
+            )).await;
+
+        Ok(())
+    }
+}
+
+const MEDIA: [&'static str; 2] = ["audio", "video"];
+
+// This is ran in a tokio task, that holds all the shared state. It's communicated to by channels.
+pub async fn handle_peer_connection_commands(peer_chan_rx: Receiver<PeerChanCommand>, peer_chan_tx: Sender<PeerChanCommand>) -> Result<()> {
+    let api = crate::sfu::api::prepare_api()?;
+
+    let mut peers: HashMap<String, Peer> = HashMap::new();
+
+    while let Ok(cmd) = peer_chan_rx.recv_async().await {
+        use PeerChanCommand::*;
+
+        match cmd {
+            DistributePacket { uuid, packet, kind } => {
+                match kind {
+                    RTPCodecType::Video => {
+                        for (_k, p) in &peers {
+                            match p.local_video_tracks.get(&uuid) {
+                                Some(track) => {
+                                    if let Err(err) = track.write_rtp(&packet).await {
+                                        println!("output track write_rtp got error: {}", err);
+                                        break;
+                                    }
+                                }
+                                None => ()
+                            }
+                        }
+                    }
+                    RTPCodecType::Audio => {
+                        for (_k, p) in &peers {
+                            match p.local_audio_tracks.get(&uuid) {
+                                Some(track) => {
+                                    if let Err(err) = track.write_rtp(&packet).await {
+                                        println!("output track write_rtp got error: {}", err);
+                                        break;
+                                    }
+                                }
+                                None => ()
+                            }
+                        }
+                    }
+                    _ => ()
+                }
+            }
+            SendIceCandidate { uuid, candidate } => {
+                let peer = peers.get(&uuid).unwrap();
+
+                peer.tx.send(SocketMessage {
+                    event: String::from("candidate"),
+                    data: candidate,
+                    uuid: uuid.to_owned()
+                }).unwrap();
+            }
+            ReceiveIceCandidate { uuid, candidate } => {
+                let peer = peers.get(&uuid).unwrap();
+                let pc = Arc::clone(&peer.pc);
+                let can: RTCIceCandidateInit = serde_json::from_str(&candidate).unwrap();
+                pc.add_ice_candidate(can).await.unwrap();
+            }
+            SendOffer { uuid } => {
+                println!("Renegotiating for {}...", uuid);
+                let peer = peers.get_mut(&uuid).unwrap();
+                let pc = Arc::clone(&peer.pc);
+
+                let offer = pc.create_offer(None).await?;
+                let offer_string = serde_json::to_string(&offer)?;
+
+                pc.set_local_description(offer).await.unwrap();
+
+                peer.tx.send(SocketMessage {
+                    event: String::from("offer"),
+                    data: offer_string,
+                    uuid: uuid.to_owned()
+                }).unwrap();
+            }
+            ReceiveOffer { uuid, sdp, tx } => {
+                let tx_clone = tx.clone();
+                match peers.get(&uuid) {
+                    Some(peer) => {
+                        let pc = Arc::clone(&peer.pc);
+                        let offer = RTCSessionDescription::offer(sdp).unwrap();
+                        pc.set_remote_description(offer).await.unwrap();
+                    }
+                    None => {
+                        let config = crate::sfu::api::prepare_configuration()?;
+
+                        let mut peer = Peer {
+                            pc: Arc::new(api.new_peer_connection(config).await?),
+                            uuid: uuid.clone(),
+                            local_video_tracks: HashMap::new(),
+                            local_audio_tracks: HashMap::new(),
+                            remote_video_track: None,
+                            remote_audio_track: None,
+                            tx,
+                        };
+                        let pc = Arc::clone(&peer.pc);
+
+                        println!("Creating new RTCPeerConnection.");
+
+                        let offer = RTCSessionDescription::offer(sdp).unwrap();
+                        pc.set_remote_description(offer).await.unwrap();
+
+                        peer.set_pc_callbacks(peer_chan_tx.clone()).await.unwrap();
+
+                        // Step 1: Adding onto every other peer, we will add a local track that will read from this
+                        // new peer's remote track.
+                        for (_key, p) in &mut peers {
+                            p.add_local_tracks(uuid.clone()).await?;
+                            println!("{} track count: {}", p.uuid, p.local_video_tracks.len());
+                        }
+
+                        // Step 2: Inserting into this peer's local_video/audio_tracks, we will create one local track for
+                        // every other currently existing peer.
+                        for (_key, p) in &peers {
+                            peer.add_local_tracks(p.uuid.clone()).await?;
+                            println!("{} track count: {}", p.uuid, p.local_video_tracks.len());
+                        }
+
+                        let answer = pc.create_answer(None).await?;
+                        let answer_string = serde_json::to_string(&answer)?;
+
+                        pc.set_local_description(answer).await.unwrap();
+
+                        tx_clone.send(SocketMessage {
+                            event: String::from("answer"),
+                            data: answer_string.to_owned(),
+                            uuid: uuid.to_owned()
+                        }).unwrap();
+
+                        // Step 3: Add the new peer to the peers list.
+                        peers.insert(uuid.to_owned(), peer);
+                    }
+                }
+            }
+            ReceiveAnswer { uuid, sdp } => {
+                let peer = peers.get(&uuid).unwrap();
+                let pc = Arc::clone(&peer.pc);
+
+                let answer = RTCSessionDescription::answer(sdp).unwrap();
+                pc.set_remote_description(answer).await.unwrap();
+            },
+            OnTrack { uuid, track } => {
+                let peer = peers.get(&uuid).unwrap();
+                let pc = Arc::clone(&peer.pc);
+
+                println!("Remote track is starting.");
+
+                // Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
+                // This is a temporary fix until we implement incoming RTCP events, then we would push a PLI only when a viewer requests it
+                let media_ssrc = track.ssrc();
+
+                if track.kind() == RTPCodecType::Video {
+                    tokio::spawn(async move {
+                        let mut result = Result::<usize>::Ok(0);
+                        while result.is_ok() {
+                            let timeout = tokio::time::sleep(Duration::from_secs(3));
+                            tokio::pin!(timeout);
+
+                            tokio::select! {
+                                _ = timeout.as_mut() =>{
+                                    result = pc.write_rtcp(&[Box::new(PictureLossIndication{
+                                        sender_ssrc: 0,
+                                        media_ssrc,
+                                    })]).await.map_err(Into::into);
+                                }
+                            };
+                        }
+                    });
+                }
+
+                let cloned_peer_chan_tx = peer_chan_tx.clone();
+                let id = uuid.clone();
+                tokio::spawn(async move {
+                    println!(
+                        "Track has started, of type {}: {}",
+                        track.payload_type(),
+                        track.codec().await.capability.mime_type
+                    );
+                    // Read RTP packets being sent to webrtc-rs
+                    while let Ok((rtp, _)) = track.read_rtp().await {
+                        cloned_peer_chan_tx.send(PeerChanCommand::DistributePacket {
+                            uuid: id.to_owned(),
+                            packet: rtp,
+                            kind: track.kind()
+                        }).unwrap();
+                    }
+
+                    println!(
+                        "on_track finished, of type {}: {}",
+                        track.payload_type(),
+                        track.codec().await.capability.mime_type
+                    );
+                });
+
+            },
+        }
+    }
+
+    Ok(())
+}

--- a/examples/sfu/sfu/signal.rs
+++ b/examples/sfu/sfu/signal.rs
@@ -1,0 +1,150 @@
+use anyhow::Result; use hyper::server::conn::AddrStream;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Request, Response, Server, StatusCode};
+use std::net::SocketAddr;
+use flume::Receiver;
+use flume::Sender;
+use futures::{sink::SinkExt, stream::StreamExt};
+use hyper_tungstenite::{tungstenite, HyperWebsocket};
+use std::convert::Infallible;
+use tungstenite::Message;
+use uuid::Uuid;
+use serde::{Deserialize, Serialize};
+use tokio_util::codec::{BytesCodec, FramedRead};
+
+static INDEX: &str = "examples/sfu/index.html";
+static NOTFOUND: &[u8] = b"Not Found";
+
+fn not_found() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(NOTFOUND.into())
+        .unwrap()
+}
+
+async fn simple_file_send(filename: &str) -> Result<Response<Body>, anyhow::Error> {
+    // Serve a file by asynchronously reading it by chunks using tokio-util crate.
+    if let Ok(file) = tokio::fs::File::open(filename).await {
+        let stream = FramedRead::new(file, BytesCodec::new());
+        let body = Body::wrap_stream(stream);
+        return Ok(Response::new(body));
+    }
+
+    Ok(not_found())
+}
+
+fn uuid() -> String {
+    Uuid::new_v4().to_hyphenated().to_string()
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SocketMessage {
+    pub event: String,
+    pub data: String,
+    pub uuid: String,
+}
+
+type Connection = (String, Sender<SocketMessage>, Receiver<SocketMessage>);
+
+pub async fn ws_sdp_signaler(port: u16) -> Receiver<Connection> {
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+
+    // A channel for passing new connections (which themselves contain channels) to the main task
+    let (conn_chan_tx, conn_chan_rx) = flume::unbounded::<Connection>();
+    let (conn_chan_2_tx, conn_chan_2_rx) = flume::unbounded::<Connection>();
+
+    let mut connections: i32 = 0;
+    tokio::spawn(async move {
+        println!("Creating connections passer");
+        while let Ok(channels) = conn_chan_rx.recv() {
+            println!("Got new connection, length is: {:?}", connections);
+            connections = connections + 1;
+            conn_chan_2_tx.send(channels).unwrap();
+        }
+    });
+
+    let make_svc = make_service_fn(move |_conn: &AddrStream| {
+        let conn_chan_tx_clone = conn_chan_tx.clone();
+
+        async move {
+            Ok::<_, Infallible>(service_fn(move |req| {
+                handle_request(req, uuid(), conn_chan_tx_clone.clone())
+            }))
+        }
+    });
+
+    let server = Server::bind(&addr).serve(make_svc);
+
+    tokio::spawn(async move {
+        if let Err(e) = server.await {
+            eprintln!("server error: {}", e);
+        }
+    });
+
+    conn_chan_2_rx
+}
+
+/// Handle a HTTP or WebSocket request.
+async fn handle_request(
+    request: Request<Body>,
+    uuid: String,
+    conn_tx: Sender<Connection>,
+) -> Result<Response<Body>, anyhow::Error> {
+    // Check if the request is a websocket upgrade request.
+    if hyper_tungstenite::is_upgrade_request(&request) {
+        let (response, websocket) = hyper_tungstenite::upgrade(request, None)?;
+
+        // Spawn a task to handle the websocket connection.
+        tokio::spawn(async move {
+            if let Err(e) = serve_websocket(websocket, uuid, conn_tx).await {
+                eprintln!("Error in websocket connection: {}", e);
+            }
+        });
+
+        // Return the response so the spawned future can continue.
+        Ok(response)
+    } else {
+        simple_file_send(INDEX).await
+    }
+}
+
+/// Handle a websocket connection.
+async fn serve_websocket(
+    websocket: HyperWebsocket,
+    uuid: String,
+    conn_tx: Sender<Connection>,
+) -> Result<(), anyhow::Error> {
+    let (out_tx, out_rx) = flume::unbounded::<SocketMessage>();
+    let (in_tx, in_rx) = flume::unbounded::<SocketMessage>();
+
+    let (mut sink, mut stream) = websocket.await?.split();
+
+    conn_tx.send((uuid.to_owned(), out_tx, in_rx)).unwrap();
+
+    tokio::spawn(async move {
+        while let Ok(message) = out_rx.recv_async().await {
+            sink.send(Message::text(serde_json::to_string(&message).unwrap())).await.unwrap();
+        }
+    });
+
+    while let Some(message) = stream.next().await {
+        match message? {
+            Message::Text(msg) => {
+                in_tx.send(serde_json::from_str(&msg).unwrap()).unwrap();
+            }
+            Message::Close(msg) => {
+                if let Some(msg) = &msg {
+                    println!(
+                        "Received close message with code {} and message: {}",
+                        msg.code, msg.reason
+                    );
+                } else {
+                    println!("Received close message");
+                }
+            }
+            _ => (),
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This branch adds a simple example of a Selective Forwarding Unit.

There's a little bit of cleanup I'll add shortly, but the big elephant in the room is this branch only works on the `main` branch of `webrtc-rs`. I've set it as such here so that people can try it out by just pulling this branch, but ultimately we can't merge this until there's a new release, at which point we can tag the whole examples version to 0.5.